### PR TITLE
Fixes oversized starter kit hero

### DIFF
--- a/css/precious-plastic-live.webflow.css
+++ b/css/precious-plastic-live.webflow.css
@@ -1061,7 +1061,7 @@
 }
 
 .hero.hero-starterkit {
-  width: 100vw;
+  background-position: 50% 50%;
   height: 80vh;
   min-width: auto;
   margin-top: 61px;


### PR DESCRIPTION
width set to 100vw calculates the wrong size in chrome/ff so I've removed the width property so that it's automatic. background position was also set to 50% on Y axis as most of the photos seem to be art-directed as centered. As it was, in a skinny window, you'd just see peoples' feet.